### PR TITLE
Refactor events controller

### DIFF
--- a/app/models/event_seed.rb
+++ b/app/models/event_seed.rb
@@ -8,5 +8,6 @@ class EventSeed < ActiveRecord::Base
   accepts_nested_attributes_for :venue
 
   validates :url, presence: true, url: { allow_blank: true }
+  validates :event, presence: true
   validates :venue, presence: true
 end

--- a/app/services/dates_to_generate_calculator.rb
+++ b/app/services/dates_to_generate_calculator.rb
@@ -15,9 +15,8 @@ class DatesToGenerateCalculator
   private
 
   class OneOffDateCalculator
-    def dates(date)
-      return [] if date < Date.today
-      [date]
+    def dates(one_date)
+      [one_date]
     end
   end
 

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -1,4 +1,8 @@
 class EventCreator
+  def initialize(event_instance_generator = EventInstanceGenerator.new)
+    @event_instance_generator = event_instance_generator
+  end
+
   def call(event_form, create_venue)
     if event_form.valid?
       event_form.venue.save! if create_venue
@@ -7,9 +11,11 @@ class EventCreator
         event: event,
         url: event_form.url,
         venue_id: event_form.venue_id
-      EventInstance.create! \
+      event_period = EventPeriod.create! \
         event_seed: event_seed,
-        date: event_form.start_date
+        frequency: event_form.frequency,
+        start_date: event_form.start_date
+      @event_instance_generator.call(event_period)
       Success.new(event)
     else
       Failure.new

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -1,6 +1,7 @@
 class EventCreator
   def call(event_form, create_venue)
     if event_form.valid?
+      event_form.venue.save! if create_venue
       event = Event.create!(name: event_form.name)
       event_seed = EventSeed.create! \
         event: event,

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -15,20 +15,41 @@ class EventCreator
         event_seed: event_seed,
         frequency: event_form.frequency,
         start_date: event_form.start_date
-      @event_instance_generator.call(event_period)
-      Success.new(event)
+      instance_creation_result = @event_instance_generator.call(event_period)
+      Success.new(event, instance_creation_result.created_dates)
     else
       Failure.new
     end
   end
 
-  Success = Struct.new(:event) do
+  class Success
+    attr_reader :event
+
+    def initialize(event, dates)
+      @event = event
+      @dates = dates || []
+    end
+
     def success?
       true
     end
 
     def message
-      "New event created"
+      "New event created. #{dates_message}"
+    end
+
+  private
+
+    def dates_message
+      case @dates.count
+      when 0 then 'No instances created.'
+      when 1 then "1 instance created: #{date_string}"
+      else "#{@dates.count} instances created: #{date_string}"
+      end
+    end
+
+    def date_string
+      @dates.map(&:to_s).join(", ") # TODO: Better way of doing this - in one step?
     end
   end
 

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -2,6 +2,13 @@ class EventCreator
   def call(event_form, create_venue)
     if event_form.valid?
       event = Event.create!(name: event_form.name)
+      event_seed = EventSeed.create! \
+        event: event,
+        url: event_form.url,
+        venue_id: event_form.venue_id
+      EventInstance.create! \
+        event_seed: event_seed,
+        date: event_form.start_date
       Success.new(event)
     else
       Failure.new

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -1,0 +1,12 @@
+class EventCreator
+  def call(event_form, create_venue)
+    event = Event.create!(name: event_form.name)
+    Result.new(true, event)
+  end
+
+  Result = Struct.new(:success?, :event) do
+    def message
+      "Event was successfully created"
+    end
+  end
+end

--- a/app/services/event_creator.rb
+++ b/app/services/event_creator.rb
@@ -1,12 +1,26 @@
 class EventCreator
   def call(event_form, create_venue)
-    event = Event.create!(name: event_form.name)
-    Result.new(true, event)
+    if event_form.valid?
+      event = Event.create!(name: event_form.name)
+      Success.new(event)
+    else
+      Failure.new
+    end
   end
 
-  Result = Struct.new(:success?, :event) do
+  Success = Struct.new(:event) do
+    def success?
+      true
+    end
+
     def message
-      "Event was successfully created"
+      "New event created"
+    end
+  end
+
+  class Failure
+    def success?
+      false
     end
   end
 end

--- a/spec/features/generate_event_instances_spec.rb
+++ b/spec/features/generate_event_instances_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe EventInstanceGenerator do
 
       context 'and the start_date is in the future' do
         let(:start_date) { today + 1 }
-        it "generates one event_instance" do
+        it "generates one event instance" do
           expect { EventInstanceGenerator.new.call(event_period) }.to change{ EventInstance.count }.by(1)
         end
       end
 
       context 'and the start_date is in the past' do
         let(:start_date) { today - 1 }
-        it "doesn't generate any event_instances" do
-          expect { EventInstanceGenerator.new.call(event_period) }.to_not change{ EventInstance.count }
+        it "generates one event instance" do
+          expect { EventInstanceGenerator.new.call(event_period) }.to change{ EventInstance.count }.by(1)
         end
       end
     end

--- a/spec/models/event_period_spec.rb
+++ b/spec/models/event_period_spec.rb
@@ -55,29 +55,19 @@ RSpec.describe EventPeriod, :type => :model do
 
       context 'and the start_date is in the future' do
         let(:start_date) { today + 1 }
-        let(:event_seed) { event_period.event_seed }
         it "generates one event instance" do
-          expect { event_period.generate }.to change{ EventInstance.count }.from(0).to(1)
-        end
-        it "creates a copy of the event seed" do
-          # TODO - find a better way to do this equality comparison
-          event_period.generate
-          event_instance = EventInstance.first
-          expect(event_instance.url).to   eq event_seed.url
-          expect(event_instance.venue).to eq event_seed.venue
-        end
-        it "returns the date it generated the event_instance for" do
-          expect(event_period.generate).to eq [event_period.start_date]
+          expect { event_period.generate }.to change{ EventInstance.count }.by(1)
         end
       end
 
       context 'and the start_date is in the past' do
         let(:start_date) { today - 1 }
-        it "doesn't generate any event_instances" do
-          expect { event_period.generate }.to_not change{ EventInstance.count }
+        it "generates one event instance" do
+          expect { event_period.generate }.to change{ EventInstance.count }.by(1)
         end
       end
     end
+
     context 'when an event repeats weekly' do
       {
         "and the start date is today" => Date.new(2001,1,1),

--- a/spec/models/event_seed_spec.rb
+++ b/spec/models/event_seed_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe EventSeed, 'Associations', :type => :model do
 end
 
 RSpec.describe EventSeed, 'Validations', :type => :model do
-  it { should validate_presence_of(:url) }
+  it { should validate_presence_of :url }
   it { should validate_presence_of :venue }
+  it { should validate_presence_of :event }
   it_should_behave_like "validates url"
 end

--- a/spec/services/dates_to_generate_calculator_spec.rb
+++ b/spec/services/dates_to_generate_calculator_spec.rb
@@ -6,19 +6,9 @@ require 'app/services/weekly_next_date_calculator' # because it's not possible t
 RSpec.describe DatesToGenerateCalculator do
   describe "#dates" do
     context "when the period is a one-off" do
-      it "returns the start date if it is in the future" do
-        event_period = one_off_event_period(start_date: Date.today + 1)
-        expect(described_class.new.dates(event_period)).to eq [Date.today + 1]
-      end
-
-      it "returns the start date if it is today" do
-        event_period = one_off_event_period(start_date: Date.today)
-        expect(described_class.new.dates(event_period)).to eq [Date.today]
-      end
-
-      it "returns no dates if the start date has already passed" do
+      it "returns just the one date (even if it's in the past)" do
         event_period = one_off_event_period(start_date: Date.today - 1)
-        expect(described_class.new.dates(event_period)).to eq []
+        expect(described_class.new.dates(event_period)).to eq [Date.today - 1]
       end
 
       def one_off_event_period(start_date:)

--- a/spec/services/event_creator_spec.rb
+++ b/spec/services/event_creator_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'app/services/event_creator'
+
+RSpec.describe EventCreator do
+  it "creates an event with the given name" do
+    event_klass = fake_event_klass
+    stub_const("Event", event_klass)
+    form = fake_event_form(name: "The Razmatazz club")
+
+    described_class.new.call(form, anything)
+
+    expect(event_klass).to have_received(:create!).with(name: "The Razmatazz club")
+  end
+
+  it "returns a successful result" do
+    stub_event_klass
+
+    expect(described_class.new.call(fake_event_form, anything).success?).to eq true
+  end
+
+  it "returns a success message" do
+    stub_event_klass
+
+    expect(described_class.new.call(fake_event_form, anything).message).to eq "Event was successfully created"
+  end
+
+  it "returns the created event" do
+    created_event = instance_double("Event")
+    event_klass = fake_event_klass
+    allow(event_klass).to receive(:create!).and_return(created_event)
+    stub_const("Event", event_klass)
+
+    expect(described_class.new.call(fake_event_form, anything).event).to eq created_event
+  end
+
+  def fake_event_form(name: "The Black Cotton Club")
+    instance_double("EventForm", name: name)
+  end
+
+  def stub_event_klass
+    stub_const("Event", fake_event_klass)
+  end
+
+  def fake_event_klass(created_event: nil)
+    class_double("Event").tap do |event_klass|
+      allow(event_klass).to receive(:create!)
+    end
+  end
+end

--- a/spec/services/event_creator_spec.rb
+++ b/spec/services/event_creator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EventCreator do
       stub_const("Event", event_klass)
       form = fake_event_form(name: "The Razmatazz club")
 
-      described_class.new.call(form, anything)
+      described_class.new.call(form, false)
 
       expect(event_klass).to have_received(:create!).with(name: "The Razmatazz club")
     end
@@ -22,7 +22,7 @@ RSpec.describe EventCreator do
         url: "http://consider.com/phlebas",
         venue_id: 17
 
-      described_class.new.call(form, anything)
+      described_class.new.call(form, false)
 
       expect(event_seed_klass).to have_received(:create!)
         .with \
@@ -36,7 +36,7 @@ RSpec.describe EventCreator do
       stub_const("EventInstance", event_instance_klass)
       form = fake_event_form(start_date: Date.new(2012, 12, 23))
 
-      described_class.new.call(form, anything)
+      described_class.new.call(form, false)
 
       expect(event_instance_klass).to have_received(:create!)
         .with \
@@ -44,13 +44,22 @@ RSpec.describe EventCreator do
           date: Date.new(2012, 12, 23)
     end
 
+    it "creates a venue object if requested" do
+      fake_venue = spy('Venue')
+      form = fake_event_form(venue: fake_venue)
+
+      described_class.new.call(form, true)
+
+      expect(fake_venue).to have_received(:save!)
+    end
+
     describe "result" do
       it "is successful" do
-        expect(described_class.new.call(fake_event_form, anything).success?).to eq true
+        expect(described_class.new.call(fake_event_form, false).success?).to eq true
       end
 
       it "returns a success message" do
-        expect(described_class.new.call(fake_event_form, anything).message).to eq "New event created"
+        expect(described_class.new.call(fake_event_form, false).message).to eq "New event created"
       end
 
       it "returns the created event" do
@@ -59,7 +68,7 @@ RSpec.describe EventCreator do
         allow(event_klass).to receive(:create!).and_return(created_event)
         stub_const("Event", event_klass)
 
-        expect(described_class.new.call(fake_event_form, anything).event).to eq created_event
+        expect(described_class.new.call(fake_event_form, false).event).to eq created_event
       end
     end
   end
@@ -68,7 +77,7 @@ RSpec.describe EventCreator do
     describe "result" do
       it "is a failure" do
         fake_invalid_event_form = instance_double("EventForm", valid?: false)
-        expect(described_class.new.call(fake_invalid_event_form, anything).success?).to eq false
+        expect(described_class.new.call(fake_invalid_event_form, false).success?).to eq false
       end
     end
   end
@@ -77,13 +86,15 @@ RSpec.describe EventCreator do
     name: "The Black Cotton Club",
     start_date: Date.today,
     url: "https://google.com",
-    venue_id: 34
+    venue_id: 34,
+    venue: nil
   )
     instance_double("EventForm",
                     name: name,
                     start_date: start_date,
                     url: url,
                     venue_id: venue_id,
+                    venue: venue,
                     valid?: true,
                    )
   end

--- a/spec/services/event_creator_spec.rb
+++ b/spec/services/event_creator_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 require 'app/services/event_creator'
 
 RSpec.describe EventCreator do
-  context "when the event was successfully created" do
+  context "when the event was intermittent and successfully created" do
+    before { stub_models }
+
     it "creates an event with the given name" do
       event_klass = fake_event_klass
       stub_const("Event", event_klass)
@@ -13,16 +15,41 @@ RSpec.describe EventCreator do
       expect(event_klass).to have_received(:create!).with(name: "The Razmatazz club")
     end
 
+    it "creates an event seed with the given url and venue_id" do
+      event_seed_klass = fake_event_seed_klass
+      stub_const("EventSeed", event_seed_klass)
+      form = fake_event_form \
+        url: "http://consider.com/phlebas",
+        venue_id: 17
+
+      described_class.new.call(form, anything)
+
+      expect(event_seed_klass).to have_received(:create!)
+        .with \
+          url: "http://consider.com/phlebas",
+          event: anything, # too complicated to test the specific value?
+          venue_id: 17
+    end
+
+    it "creates an event instance with the given date" do
+      event_instance_klass = fake_event_instance_klass
+      stub_const("EventInstance", event_instance_klass)
+      form = fake_event_form(start_date: Date.new(2012, 12, 23))
+
+      described_class.new.call(form, anything)
+
+      expect(event_instance_klass).to have_received(:create!)
+        .with \
+          event_seed: anything, # too complicated to test the specific value?
+          date: Date.new(2012, 12, 23)
+    end
+
     describe "result" do
       it "is successful" do
-        stub_event_klass
-
         expect(described_class.new.call(fake_event_form, anything).success?).to eq true
       end
 
       it "returns a success message" do
-        stub_event_klass
-
         expect(described_class.new.call(fake_event_form, anything).message).to eq "New event created"
       end
 
@@ -40,24 +67,48 @@ RSpec.describe EventCreator do
   context "when there are validation errors" do
     describe "result" do
       it "is a failure" do
-        stub_const("Event", double)
         fake_invalid_event_form = instance_double("EventForm", valid?: false)
         expect(described_class.new.call(fake_invalid_event_form, anything).success?).to eq false
       end
     end
   end
 
-  def fake_event_form(name: "The Black Cotton Club")
-    instance_double("EventForm", name: name, valid?: true)
+  def fake_event_form(
+    name: "The Black Cotton Club",
+    start_date: Date.today,
+    url: "https://google.com",
+    venue_id: 34
+  )
+    instance_double("EventForm",
+                    name: name,
+                    start_date: start_date,
+                    url: url,
+                    venue_id: venue_id,
+                    valid?: true,
+                   )
   end
 
-  def stub_event_klass
+  def stub_models
     stub_const("Event", fake_event_klass)
+    stub_const("EventSeed", fake_event_seed_klass)
+    stub_const("EventInstance", fake_event_instance_klass)
   end
 
   def fake_event_klass(created_event: nil)
     class_double("Event").tap do |event_klass|
       allow(event_klass).to receive(:create!)
+    end
+  end
+
+  def fake_event_seed_klass
+    class_double("EventSeed").tap do |event_seed_klass|
+      allow(event_seed_klass).to receive(:create!)
+    end
+  end
+
+  def fake_event_instance_klass
+    class_double("EventInstance").tap do |event_instance_klass|
+      allow(event_instance_klass).to receive(:create!)
     end
   end
 end

--- a/spec/services/event_creator_spec.rb
+++ b/spec/services/event_creator_spec.rb
@@ -2,39 +2,53 @@ require 'spec_helper'
 require 'app/services/event_creator'
 
 RSpec.describe EventCreator do
-  it "creates an event with the given name" do
-    event_klass = fake_event_klass
-    stub_const("Event", event_klass)
-    form = fake_event_form(name: "The Razmatazz club")
+  context "when the event was successfully created" do
+    it "creates an event with the given name" do
+      event_klass = fake_event_klass
+      stub_const("Event", event_klass)
+      form = fake_event_form(name: "The Razmatazz club")
 
-    described_class.new.call(form, anything)
+      described_class.new.call(form, anything)
 
-    expect(event_klass).to have_received(:create!).with(name: "The Razmatazz club")
+      expect(event_klass).to have_received(:create!).with(name: "The Razmatazz club")
+    end
+
+    describe "result" do
+      it "is successful" do
+        stub_event_klass
+
+        expect(described_class.new.call(fake_event_form, anything).success?).to eq true
+      end
+
+      it "returns a success message" do
+        stub_event_klass
+
+        expect(described_class.new.call(fake_event_form, anything).message).to eq "New event created"
+      end
+
+      it "returns the created event" do
+        created_event = instance_double("Event")
+        event_klass = fake_event_klass
+        allow(event_klass).to receive(:create!).and_return(created_event)
+        stub_const("Event", event_klass)
+
+        expect(described_class.new.call(fake_event_form, anything).event).to eq created_event
+      end
+    end
   end
 
-  it "returns a successful result" do
-    stub_event_klass
-
-    expect(described_class.new.call(fake_event_form, anything).success?).to eq true
-  end
-
-  it "returns a success message" do
-    stub_event_klass
-
-    expect(described_class.new.call(fake_event_form, anything).message).to eq "Event was successfully created"
-  end
-
-  it "returns the created event" do
-    created_event = instance_double("Event")
-    event_klass = fake_event_klass
-    allow(event_klass).to receive(:create!).and_return(created_event)
-    stub_const("Event", event_klass)
-
-    expect(described_class.new.call(fake_event_form, anything).event).to eq created_event
+  context "when there are validation errors" do
+    describe "result" do
+      it "is a failure" do
+        stub_const("Event", double)
+        fake_invalid_event_form = instance_double("EventForm", valid?: false)
+        expect(described_class.new.call(fake_invalid_event_form, anything).success?).to eq false
+      end
+    end
   end
 
   def fake_event_form(name: "The Black Cotton Club")
-    instance_double("EventForm", name: name)
+    instance_double("EventForm", name: name, valid?: true)
   end
 
   def stub_event_klass


### PR DESCRIPTION
Extract an EventCreator service to abstract away all the work involved in creating the various records related to an Event.
